### PR TITLE
Fixed call to Py_SetPythonHome and Py_SetProgramName. Added support for Py_SetPythonPath

### DIFF
--- a/pythonnet/src/runtime/pythonengine.cs
+++ b/pythonnet/src/runtime/pythonengine.cs
@@ -64,6 +64,22 @@ namespace Python.Runtime {
             }
         }
 
+        public static string PythonPath {
+            get
+            {
+                string result = Runtime.Py_GetPath();
+                if (result == null)
+                {
+                    return "";
+                }
+                return result;
+            }
+            set
+            {
+                Runtime.Py_SetPath(value);
+            }
+        }
+
         public static string Version {
             get { 
                 return Runtime.Py_GetVersion(); 

--- a/pythonnet/src/runtime/runtime.cs
+++ b/pythonnet/src/runtime/runtime.cs
@@ -583,25 +583,70 @@ namespace Python.Runtime {
     PyEval_GetLocals();
 
 
+#if PYTHON32 || PYTHON33 || PYTHON34
     [DllImport(Runtime.dll, CallingConvention=CallingConvention.Cdecl,
          ExactSpelling=true, CharSet=CharSet.Ansi)]
+    [return: MarshalAs(UnmanagedType.LPWStr)]
         internal unsafe static extern string
         Py_GetProgramName();
 
     [DllImport(Runtime.dll, CallingConvention=CallingConvention.Cdecl,
         ExactSpelling=true, CharSet=CharSet.Ansi)]
         internal unsafe static extern void
-        Py_SetProgramName(string name);
+        Py_SetProgramName([MarshalAsAttribute(UnmanagedType.LPWStr)]string name);
 
     [DllImport(Runtime.dll, CallingConvention=CallingConvention.Cdecl,
         ExactSpelling=true, CharSet=CharSet.Ansi)]
+    [return: MarshalAs(UnmanagedType.LPWStr)]
         internal unsafe static extern string
         Py_GetPythonHome();
 
     [DllImport(Runtime.dll, CallingConvention=CallingConvention.Cdecl,
         ExactSpelling=true, CharSet=CharSet.Ansi)]
         internal unsafe static extern void
-        Py_SetPythonHome(string home);
+        Py_SetPythonHome([MarshalAsAttribute(UnmanagedType.LPWStr)]string home);
+
+    [DllImport(Runtime.dll, CallingConvention=CallingConvention.Cdecl,
+        ExactSpelling=true, CharSet=CharSet.Ansi)]
+    [return: MarshalAs(UnmanagedType.LPWStr)]
+        internal unsafe static extern string
+        Py_GetPath();
+
+    [DllImport(Runtime.dll, CallingConvention=CallingConvention.Cdecl,
+        ExactSpelling=true, CharSet=CharSet.Ansi)]
+        internal unsafe static extern void
+        Py_SetPath([MarshalAsAttribute(UnmanagedType.LPWStr)]string home);
+#else
+    [DllImport(Runtime.dll, CallingConvention = CallingConvention.Cdecl,
+          ExactSpelling = true, CharSet = CharSet.Ansi)]
+    internal unsafe static extern string
+    Py_GetProgramName();
+
+    [DllImport(Runtime.dll, CallingConvention = CallingConvention.Cdecl,
+        ExactSpelling = true, CharSet = CharSet.Ansi)]
+    internal unsafe static extern void
+    Py_SetProgramName(string name);
+
+    [DllImport(Runtime.dll, CallingConvention = CallingConvention.Cdecl,
+        ExactSpelling = true, CharSet = CharSet.Ansi)]
+    internal unsafe static extern string
+    Py_GetPythonHome();
+
+    [DllImport(Runtime.dll, CallingConvention = CallingConvention.Cdecl,
+        ExactSpelling = true, CharSet = CharSet.Ansi)]
+    internal unsafe static extern void
+    Py_SetPythonHome(string home);
+
+    [DllImport(Runtime.dll, CallingConvention = CallingConvention.Cdecl,
+        ExactSpelling = true, CharSet = CharSet.Ansi)]
+    internal unsafe static extern string
+    Py_GetPath();
+
+    [DllImport(Runtime.dll, CallingConvention = CallingConvention.Cdecl,
+        ExactSpelling = true, CharSet = CharSet.Ansi)]
+    internal unsafe static extern void
+    Py_SetPath(string home);
+#endif
 
     [DllImport(Runtime.dll, CallingConvention=CallingConvention.Cdecl,
         ExactSpelling=true, CharSet=CharSet.Ansi)]


### PR DESCRIPTION
In Python3, Py_SetPythonHome and Py_SetProgramName use Unicode strings instead of Ansi strings
Added support for setting the Python Path which is very useful when running an embedded interpreter
